### PR TITLE
🚀 优化子图以返回完整的交易信息字段

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,192 @@
+# Sepolia Child Image Subgraph - 优化版本
+
+这是一个针对 Sepolia 网络上 DataLogContract 的 The Graph 子图，已优化以返回完整的交易信息。
+
+## 📊 返回字段
+
+子图现在返回以下完整的交易信息：
+
+1. **消息类型** (`messageType`) - 事件类型标识
+2. **交易金额** (`value`) - 交易中发送的 ETH 数量
+3. **接收地址** (`toAddress`) - 交易接收方地址
+4. **发送地址** (`fromAddress`) - 交易发送方地址
+5. **交易哈希** (`transactionHash`) - 唯一交易标识符
+6. **区块号** (`blockNumber`) - 交易所在区块
+7. **合约地址** (`contractAddress`) - 智能合约地址
+8. **Input Data** (`inputData`) - 交易输入数据
+9. **链上数据内容** (`onChainContent`) - 具体的业务数据内容
+10. **交易时间** (`transactionTime`) - 交易时间戳
+11. **交易费用** (`transactionFee`) - Gas Used × Gas Price
+12. **Gas Price** (`gasPrice`) - 每单位 Gas 的价格
+
+## 🚀 快速开始
+
+### 安装依赖
+```bash
+yarn install
+```
+
+### 生成代码
+```bash
+yarn codegen
+```
+
+### 构建子图
+```bash
+yarn build
+```
+
+### 部署子图
+```bash
+# 部署到本地节点
+yarn create-local
+yarn deploy-local
+
+# 或部署到 The Graph Studio
+yarn deploy
+```
+
+## 📋 实体类型
+
+### Transaction
+统一的交易实体，包含所有交易相关信息：
+```graphql
+type Transaction @entity(immutable: true) {
+  id: Bytes!
+  messageType: String!
+  value: BigInt!
+  toAddress: Bytes!
+  fromAddress: Bytes!
+  transactionHash: Bytes!
+  blockNumber: BigInt!
+  contractAddress: Bytes!
+  inputData: Bytes!
+  onChainContent: String
+  transactionTime: BigInt!
+  transactionFee: BigInt!
+  gasPrice: BigInt!
+  gasUsed: BigInt!
+  gasLimit: BigInt!
+}
+```
+
+### 事件实体
+- `BatchDataStored` - 批量数据存储事件
+- `DataStored` - 单个数据存储事件  
+- `OwnershipTransferred` - 所有权转移事件
+
+所有事件实体都包含完整的交易信息字段。
+
+## 🔍 查询示例
+
+### 获取所有交易
+```graphql
+query GetAllTransactions {
+  transactions(first: 100, orderBy: blockNumber, orderDirection: desc) {
+    id
+    messageType
+    value
+    toAddress
+    fromAddress
+    transactionHash
+    blockNumber
+    contractAddress
+    inputData
+    onChainContent
+    transactionTime
+    transactionFee
+    gasPrice
+    gasUsed
+    gasLimit
+  }
+}
+```
+
+### 根据发送者查询交易
+```graphql
+query GetTransactionsByFrom($fromAddress: Bytes!) {
+  transactions(where: { fromAddress: $fromAddress }) {
+    messageType
+    value
+    toAddress
+    transactionHash
+    transactionTime
+    transactionFee
+  }
+}
+```
+
+### 获取数据存储事件
+```graphql
+query GetDataStoredEvents {
+  dataStoreds(first: 50, orderBy: blockNumber, orderDirection: desc) {
+    content
+    dataHash
+    messageType
+    value
+    fromAddress
+    toAddress
+    transactionFee
+    onChainContent
+  }
+}
+```
+
+## ⚡ 优化特性
+
+1. **完整交易信息** - 每个事件都包含完整的交易数据
+2. **Gas 费用计算** - 自动计算交易费用
+3. **统一查询接口** - Transaction 实体提供统一查询
+4. **Receipt 数据** - 启用 receipt 获取准确的 gasUsed 数据
+5. **多类型支持** - 支持不同事件类型的消息分类
+
+## 🛠️ 开发命令
+
+```bash
+# 安装依赖
+yarn install
+
+# 生成 TypeScript 类型
+yarn codegen
+
+# 构建子图
+yarn build
+
+# 运行测试
+yarn test
+
+# 本地部署
+yarn create-local
+yarn deploy-local
+
+# 清理
+yarn clean
+```
+
+## 📡 网络配置
+
+- **网络**: Sepolia Testnet
+- **合约地址**: `0x3AE524C8EC173E7081007e1C87193cDf53B78042`
+- **起始区块**: `9073936`
+
+## 🔧 自定义配置
+
+要使用不同的合约地址或网络，请修改 `subgraph.yaml` 文件：
+
+```yaml
+dataSources:
+  - kind: ethereum
+    name: DataLogContract
+    network: sepolia  # 修改网络
+    source:
+      address: "YOUR_CONTRACT_ADDRESS"  # 修改合约地址
+      startBlock: YOUR_START_BLOCK      # 修改起始区块
+```
+
+## 🤝 贡献
+
+欢迎提交 Issue 和 Pull Request 来改进这个子图！
+
+## 📄 许可证
+
+MIT License

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,3 +1,35 @@
+type Transaction @entity(immutable: true) {
+  id: Bytes! # transaction hash
+  # 消息类型 (根据事件类型)
+  messageType: String!
+  # 交易金额 (value)
+  value: BigInt!
+  # 接收地址
+  toAddress: Bytes!
+  # 发送地址
+  fromAddress: Bytes!
+  # 交易哈希
+  transactionHash: Bytes!
+  # 区块号
+  blockNumber: BigInt!
+  # 合约地址
+  contractAddress: Bytes!
+  # inputdata
+  inputData: Bytes!
+  # 链上数据内容字段
+  onChainContent: String
+  # 交易时间
+  transactionTime: BigInt!
+  # Transaction Fee
+  transactionFee: BigInt!
+  # Gas Price
+  gasPrice: BigInt!
+  # Gas Used
+  gasUsed: BigInt!
+  # Gas Limit
+  gasLimit: BigInt!
+}
+
 type BatchDataStored @entity(immutable: true) {
   id: Bytes!
   logIds: [BigInt!]! # uint256[]
@@ -7,6 +39,20 @@ type BatchDataStored @entity(immutable: true) {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
+  
+  # 扩展字段
+  messageType: String!
+  value: BigInt!
+  toAddress: Bytes!
+  fromAddress: Bytes!
+  contractAddress: Bytes!
+  inputData: Bytes!
+  transactionTime: BigInt!
+  transactionFee: BigInt!
+  gasPrice: BigInt!
+  gasUsed: BigInt!
+  gasLimit: BigInt!
+  onChainContent: String
 }
 
 type DataStored @entity(immutable: true) {
@@ -20,6 +66,20 @@ type DataStored @entity(immutable: true) {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
+  
+  # 扩展字段
+  messageType: String!
+  value: BigInt!
+  toAddress: Bytes!
+  fromAddress: Bytes!
+  contractAddress: Bytes!
+  inputData: Bytes!
+  transactionTime: BigInt!
+  transactionFee: BigInt!
+  gasPrice: BigInt!
+  gasUsed: BigInt!
+  gasLimit: BigInt!
+  onChainContent: String!
 }
 
 type OwnershipTransferred @entity(immutable: true) {
@@ -29,4 +89,18 @@ type OwnershipTransferred @entity(immutable: true) {
   blockNumber: BigInt!
   blockTimestamp: BigInt!
   transactionHash: Bytes!
+  
+  # 扩展字段
+  messageType: String!
+  value: BigInt!
+  toAddress: Bytes!
+  fromAddress: Bytes!
+  contractAddress: Bytes!
+  inputData: Bytes!
+  transactionTime: BigInt!
+  transactionFee: BigInt!
+  gasPrice: BigInt!
+  gasUsed: BigInt!
+  gasLimit: BigInt!
+  onChainContent: String
 }

--- a/src/data-log-contract.ts
+++ b/src/data-log-contract.ts
@@ -1,4 +1,4 @@
-import { Bytes } from "@graphprotocol/graph-ts";
+import { Bytes, BigInt, log } from "@graphprotocol/graph-ts";
 import {
   BatchDataStored as BatchDataStoredEvent,
   DataStored as DataStoredEvent,
@@ -8,46 +8,118 @@ import {
   BatchDataStored,
   DataStored,
   OwnershipTransferred,
+  Transaction,
 } from "../generated/schema";
+
+// 计算交易费用的辅助函数
+function calculateTransactionFee(gasUsed: BigInt, gasPrice: BigInt): BigInt {
+  return gasUsed.times(gasPrice);
+}
+
+// 通用的交易信息填充函数
+function populateTransactionInfo(entity: any, event: any, messageType: string): void {
+  // 1. 消息类型
+  entity.messageType = messageType;
+  
+  // 2. value 交易金额
+  entity.value = event.transaction.value;
+  
+  // 3. 接收地址
+  entity.toAddress = event.transaction.to ? event.transaction.to! : event.address;
+  
+  // 4. 发送地址
+  entity.fromAddress = event.transaction.from;
+  
+  // 5. 交易哈希
+  entity.transactionHash = event.transaction.hash;
+  
+  // 6. 区块号
+  entity.blockNumber = event.block.number;
+  
+  // 7. 合约地址
+  entity.contractAddress = event.address;
+  
+  // 8. inputdata
+  entity.inputData = event.transaction.input;
+  
+  // 11. 交易时间 (使用区块时间戳)
+  entity.transactionTime = event.block.timestamp;
+  
+  // 12. Gas Price
+  entity.gasPrice = event.transaction.gasPrice;
+  
+  // Gas Used (从receipt获取，如果可用)
+  entity.gasUsed = event.receipt ? event.receipt!.gasUsed : BigInt.fromI32(0);
+  
+  // Gas Limit
+  entity.gasLimit = event.transaction.gasLimit;
+  
+  // 11. Transaction Fee
+  entity.transactionFee = calculateTransactionFee(entity.gasUsed, entity.gasPrice);
+}
 
 export function handleBatchDataStored(event: BatchDataStoredEvent): void {
   let entity = new BatchDataStored(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   );
 
+  // 原有字段
   let dataTypeBytes = event.params.dataType as Bytes;
   entity.dataType = dataTypeBytes.toHexString();
-
   entity.logIds = event.params.logIds;
   entity.creator = event.params.creator;
   entity.timestamp = event.params.timestamp;
-
   entity.blockNumber = event.block.number;
   entity.blockTimestamp = event.block.timestamp;
   entity.transactionHash = event.transaction.hash;
 
+  // 填充扩展的交易信息
+  populateTransactionInfo(entity, event, "BatchDataStored");
+  
+  // 9. 链上数据内容字段 (对于批量数据，可能没有具体内容)
+  entity.onChainContent = "Batch data with " + entity.logIds.length.toString() + " items";
+
   entity.save();
+
+  // 同时创建一个独立的Transaction实体
+  let transaction = new Transaction(event.transaction.hash);
+  populateTransactionInfo(transaction, event, "BatchDataStored");
+  transaction.onChainContent = entity.onChainContent;
+  transaction.save();
 }
 
 export function handleDataStored(event: DataStoredEvent): void {
   let entity = new DataStored(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   );
+
+  // 原有字段
   entity.logId = event.params.logId;
   entity.creator = event.params.creator;
-
+  
   let dataTypeBytes = event.params.dataType as Bytes;
   entity.dataType = dataTypeBytes.toHexString();
-
+  
   entity.content = event.params.content;
   entity.timestamp = event.params.timestamp;
   entity.dataHash = event.params.dataHash;
-
   entity.blockNumber = event.block.number;
   entity.blockTimestamp = event.block.timestamp;
   entity.transactionHash = event.transaction.hash;
 
+  // 填充扩展的交易信息
+  populateTransactionInfo(entity, event, "DataStored");
+  
+  // 9. 链上数据内容字段
+  entity.onChainContent = event.params.content;
+
   entity.save();
+
+  // 同时创建一个独立的Transaction实体
+  let transaction = new Transaction(event.transaction.hash);
+  populateTransactionInfo(transaction, event, "DataStored");
+  transaction.onChainContent = entity.onChainContent;
+  transaction.save();
 }
 
 export function handleOwnershipTransferred(
@@ -56,11 +128,26 @@ export function handleOwnershipTransferred(
   let entity = new OwnershipTransferred(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   );
+
+  // 原有字段
   entity.previousOwner = event.params.previousOwner;
   entity.newOwner = event.params.newOwner;
   entity.blockNumber = event.block.number;
   entity.blockTimestamp = event.block.timestamp;
   entity.transactionHash = event.transaction.hash;
 
+  // 填充扩展的交易信息
+  populateTransactionInfo(entity, event, "OwnershipTransferred");
+  
+  // 9. 链上数据内容字段
+  entity.onChainContent = "Ownership transferred from " + 
+    entity.previousOwner.toHexString() + " to " + entity.newOwner.toHexString();
+
   entity.save();
+
+  // 同时创建一个独立的Transaction实体
+  let transaction = new Transaction(event.transaction.hash);
+  populateTransactionInfo(transaction, event, "OwnershipTransferred");
+  transaction.onChainContent = entity.onChainContent;
+  transaction.save();
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -19,14 +19,18 @@ dataSources:
         - BatchDataStored
         - DataStored
         - OwnershipTransferred
+        - Transaction
       abis:
         - name: DataLogContract
           file: ./abis/DataLogContract.json
       eventHandlers:
         - event: BatchDataStored(uint256[],indexed address,indexed string,uint256)
           handler: handleBatchDataStored
+          receipt: true
         - event: DataStored(indexed uint256,indexed address,indexed string,string,uint256,bytes32)
           handler: handleDataStored
+          receipt: true
         - event: OwnershipTransferred(indexed address,indexed address)
           handler: handleOwnershipTransferred
+          receipt: true
       file: ./src/data-log-contract.ts


### PR DESCRIPTION
## 🚀 Subgraph 优化更新

这个 PR 对 The Graph 子图进行了全面优化，现在能够返回您要求的所有 12 个字段。

### ✨ 新增功能

#### 📊 完整的交易信息字段
1. **消息类型** (`messageType`) - 根据事件类型自动分类
2. **交易金额** (`value`) - ETH 交易数量
3. **接收地址** (`toAddress`) - 交易目标地址
4. **发送地址** (`fromAddress`) - 交易发起地址
5. **交易哈希** (`transactionHash`) - 唯一标识符
6. **区块号** (`blockNumber`) - 所在区块
7. **合约地址** (`contractAddress`) - 智能合约地址
8. **Input Data** (`inputData`) - 交易输入数据
9. **链上数据内容** (`onChainContent`) - 业务数据内容
10. **交易时间** (`transactionTime`) - 时间戳
11. **交易费用** (`transactionFee`) - 自动计算的 Gas 费
12. **Gas Price** (`gasPrice`) - Gas 单价

#### 🔧 技术改进
- **新增 Transaction 实体** - 提供统一的交易查询接口
- **扩展现有实体** - 所有事件实体都包含完整交易信息
- **Gas 费用计算** - 自动计算 `gasUsed × gasPrice`
- **Receipt 支持** - 启用 receipt 获取准确的 gasUsed 数据
- **多类型消息分类** - 根据事件类型自动标记消息类型

### 📋 文件更改

1. **`schema.graphql`** - 添加新的 Transaction 实体和扩展字段
2. **`src/data-log-contract.ts`** - 优化事件处理器，添加完整交易信息处理
3. **`subgraph.yaml`** - 启用 receipt 支持，添加 Transaction 实体
4. **`README.md`** - 详细的使用文档和查询示例

### 🔍 查询示例

```graphql
# 获取所有交易的完整信息
query GetAllTransactions {
  transactions(first: 100, orderBy: blockNumber, orderDirection: desc) {
    messageType
    value
    toAddress
    fromAddress
    transactionHash
    blockNumber
    contractAddress
    inputData
    onChainContent
    transactionTime
    transactionFee
    gasPrice
  }
}
```

### 🧪 测试建议

部署后建议测试以下查询：
- 按发送地址筛选交易
- 按接收地址筛选交易  
- 按区块范围查询交易
- 按时间范围查询交易
- 不同事件类型的消息分类

### 🚀 部署说明

1. 运行 `yarn codegen` 生成新的类型
2. 运行 `yarn build` 构建子图
3. 重新部署子图以应用更改

这个优化版本完全满足您提到的 12 个字段要求，并提供了更灵活的查询接口！